### PR TITLE
fix: fix typos in payload field names

### DIFF
--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/bucket-policy-changes/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/bucket-policy-changes/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/cloudtrail-changes/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/cloudtrail-changes/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/cmk-changes/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/cmk-changes/decide.rego
@@ -48,7 +48,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/config-changes/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/config-changes/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/console-auth-failure/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/console-auth-failure/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/console-root-user-usage/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/console-root-user-usage/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/console-signin-mfa/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/console-signin-mfa/decide.rego
@@ -50,7 +50,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/iam-policy-changes/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/iam-policy-changes/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/nacl-changes/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/nacl-changes/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/network-gateway-changes/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/network-gateway-changes/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/organizations-changes/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/organizations-changes/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/route-table-changes/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/route-table-changes/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/security-group-changes/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/security-group-changes/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/unauthorized-api-calls/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/unauthorized-api-calls/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/vpc-changes/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/vpc-changes/decide.rego
@@ -47,7 +47,7 @@ cis_based_notification_paths(account) := x {
 		path := {
 			"trail_name": trail.metadata.displayName,
 			"metric_name": metric.name,
-			"alarm_name:": alarm.metadata.displayName,
+			"alarm_name": alarm.metadata.displayName,
 			"sns_topic_arn": topic.arn,
 		}
 	]


### PR DESCRIPTION
This PR fixes some typos found in payload field names. 

Disclaimer: These typos will NOT prevent policies from making proper decisions (i.e. the security check resulsts are legitimate even with these typos), but they're just confusing!