### PR TITLE
chore: add `__typename` fields just for helping some GraphQL code generators

### DIFF
--- a/workflows/cis-benchmark/aws-v1.5.0/cloudtrail/usage/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/cloudtrail/usage/decide.graphql
@@ -14,6 +14,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               includeManagementEvents
               readWriteType

--- a/workflows/cis-benchmark/aws-v1.5.0/iam/user-group-permission-assignment/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/iam/user-group-permission-assignment/decide.graphql
@@ -8,6 +8,7 @@
             displayName
           }
           policies {
+            __typename
             ... on AWSIAMUserInlinePolicy {
               name
             }

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/bucket-policy-changes/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/bucket-policy-changes/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/cloudtrail-changes/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/cloudtrail-changes/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/cmk-changes/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/cmk-changes/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/config-changes/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/config-changes/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/console-auth-failure/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/console-auth-failure/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/console-root-user-usage/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/console-root-user-usage/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/console-signin-mfa/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/console-signin-mfa/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/iam-policy-changes/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/iam-policy-changes/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/nacl-changes/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/nacl-changes/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/network-gateway-changes/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/network-gateway-changes/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/organizations-changes/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/organizations-changes/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/route-table-changes/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/route-table-changes/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/security-group-changes/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/security-group-changes/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/unauthorized-api-calls/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/unauthorized-api-calls/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/logmetric/vpc-changes/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/logmetric/vpc-changes/decide.graphql
@@ -29,6 +29,7 @@
             isLogging
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               includeManagementEvents
@@ -47,6 +48,7 @@
       }
       cloudWatch {
         alarms {
+          __typename
           ... on AWSCloudWatchMetricAlarm {
             metadata {
               id
@@ -54,10 +56,12 @@
             }
             metricName
             alarmActions {
+              __typename
               ... on AWSCloudWatchAlarmActionNotification {
                 __typename
                 arn
                 topic {
+                  __typename
                   ... on AWSSNSTopicFifo {
                     metadata {
                       id

--- a/workflows/cis-benchmark/aws-v1.5.0/rds/instance-accessibility/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/rds/instance-accessibility/decide.graphql
@@ -3,6 +3,7 @@
     accounts {
       rds {
         instances {
+          __typename
           ... on AWSRDSGenericDatabaseInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/aws-v1.5.0/rds/instance-auto-upgrade/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/rds/instance-auto-upgrade/decide.graphql
@@ -3,6 +3,7 @@
     accounts {
       rds {
         instances {
+          __typename
           ... on AWSRDSGenericDatabaseInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/aws-v1.5.0/rds/instance-encryption/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/rds/instance-encryption/decide.graphql
@@ -3,6 +3,7 @@
     accounts {
       rds {
         instances {
+          __typename
           ... on AWSRDSGenericDatabaseInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/aws-v1.5.0/s3/bucket-read-trail/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/s3/bucket-read-trail/decide.graphql
@@ -12,6 +12,7 @@
             displayName
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               dataResources {

--- a/workflows/cis-benchmark/aws-v1.5.0/s3/bucket-write-trail/decide.graphql
+++ b/workflows/cis-benchmark/aws-v1.5.0/s3/bucket-write-trail/decide.graphql
@@ -12,6 +12,7 @@
             displayName
           }
           eventSelectors {
+            __typename
             ... on AWSCloudTrailBasicEventSelector {
               __typename
               dataResources {

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/credential/api-keys-restriction/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/credential/api-keys-restriction/decide.graphql
@@ -10,6 +10,7 @@
           deletedAt
           restriction {
             applicationRestriction {
+              __typename
               ... on GoogleCloudAPIKeyApplicationBrowserRestriction {
                 __typename
                 allowedReferrers

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/iam/principal-source/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/iam/principal-source/decide.graphql
@@ -8,6 +8,7 @@
       iamPolicy {
         bindings {
           members {
+            __typename
             ... on GoogleCloudIAMPrincipalUser {
               __typename
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/iam/service-account-admin-separation/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/iam/service-account-admin-separation/decide.graphql
@@ -9,6 +9,7 @@
         bindings {
           role
           members {
+            __typename
             ... on GoogleCloudIAMPrincipalServiceAccount {
               id
               email

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/iam/service-account-project-impersonation-role/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/iam/service-account-project-impersonation-role/decide.graphql
@@ -8,6 +8,7 @@ query {
       iamPolicy {
         bindings {
           members {
+            __typename
             id
           }
           role

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/kms/admin-separation/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/kms/admin-separation/decide.graphql
@@ -9,6 +9,7 @@
         bindings {
           role
           members {
+            __typename
             ... on GoogleCloudIAMPrincipalUser {
               id
               email

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/kms/key-accessibility/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/kms/key-accessibility/decide.graphql
@@ -12,6 +12,7 @@
               bindings {
                 role
                 members {
+                  __typename
                   ... on GoogleCloudIAMPrincipalAllAuthenticatedUsers {
                     id
                   }

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-accessibility/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-accessibility/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLMySQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-backup/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-backup/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLMySQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-connection/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-connection/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLMySQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-mysql-local-infile/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-mysql-local-infile/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLMySQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-mysql-show-database/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-mysql-show-database/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLMySQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-connections/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-connections/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLPostgreSQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-disconnections/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-disconnections/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLPostgreSQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-error-verbosity/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-error-verbosity/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLPostgreSQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-hostname/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-hostname/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLPostgreSQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-min-duration-statement/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-min-duration-statement/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLPostgreSQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-min-error-statement/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-min-error-statement/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLPostgreSQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-min-messages/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-min-messages/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLPostgreSQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-statement/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-postgresql-log-statement/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLPostgreSQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-public-ip/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-public-ip/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLMySQLInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-3625-trace-flag/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-3625-trace-flag/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLSQLServerInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-contained-db-authentication/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-contained-db-authentication/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLSQLServerInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-cross-db-ownership-chaining/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-cross-db-ownership-chaining/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLSQLServerInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-external-scripts/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-external-scripts/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLSQLServerInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-remote-access/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-remote-access/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLSQLServerInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-user-connections/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-user-connections/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLSQLServerInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-user-options/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/sql/instance-sqlserver-user-options/decide.graphql
@@ -3,6 +3,7 @@
     projects {
       cloudSql {
         instances {
+          __typename
           ... on GoogleCloudSQLSQLServerInstance {
             metadata {
               id

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/storage/bucket-accessibility/decide.graphql
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/storage/bucket-accessibility/decide.graphql
@@ -15,6 +15,7 @@
             bindings {
               role
               members {
+                __typename
                 id
               }
             }

--- a/workflows/csp/aws-fsbp/elb/alb-header/decide.graphql
+++ b/workflows/csp/aws-fsbp/elb/alb-header/decide.graphql
@@ -3,6 +3,7 @@ query {
     accounts {
       elb {
         loadBalancers(condition: { types: [APPLICATION] }) {
+          __typename
           ... on AWSELBApplicationLoadBalancer {
             metadata {
               id

--- a/workflows/csp/aws-fsbp/elb/deletion-protection/decide.graphql
+++ b/workflows/csp/aws-fsbp/elb/deletion-protection/decide.graphql
@@ -3,6 +3,7 @@ query {
     accounts {
       elb {
         loadBalancers(condition: { types: [APPLICATION] }) {
+          __typename
           ... on AWSELBApplicationLoadBalancer {
             metadata {
               id

--- a/workflows/csp/aws-fsbp/elb/logging/decide.graphql
+++ b/workflows/csp/aws-fsbp/elb/logging/decide.graphql
@@ -3,6 +3,7 @@ query {
     accounts {
       elb {
         loadBalancers(condition: { types: [APPLICATION] }) {
+          __typename
           ... on AWSELBApplicationLoadBalancer {
             metadata {
               id


### PR DESCRIPTION
This PR starts to fetch `__typename` fields in union fields.

*Some GraphQL code generator toolchains require the field explicitly. The old implementations are still legitimate, but this PR helps users integrate the policy codes with those tools.