### PR TITLE
chore: bump up Rego SDK

### DIFF
--- a/workflows/cis-benchmark/googlecloud-v1.3.0/storage/bucket-uniform-bucket-level-access/decide.rego
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/storage/bucket-uniform-bucket-level-access/decide.rego
@@ -11,6 +11,6 @@ decisions[d] {
 	d := shisho.decision.googlecloud.storage.bucket_uniform_bucket_level_access({
 		"allowed": allowed,
 		"subject": bucket.metadata.id,
-		"payload": shisho.decision.googlecloud.storage.bucket_uniform_bucket_level_access_payload({"uniform_access_enabled", bucket.uniformBucketLevelAccess.enabled}),
+		"payload": shisho.decision.googlecloud.storage.bucket_uniform_bucket_level_access_payload({"uniform_access_enabled": bucket.uniformBucketLevelAccess.enabled}),
 	})
 }

--- a/workflows/csp/aws-fsbp/ecs/task/decide_test.rego
+++ b/workflows/csp/aws-fsbp/ecs/task/decide_test.rego
@@ -3,9 +3,6 @@ package policy.aws.ecs.task
 import data.shisho
 import future.keywords
 
-import data.shisho
-import future.keywords
-
 test_task_with_writeable_root_fs_container_denied if {
 	td := {
 		"arn": "arn:aws:ecs:ap-northeast-1:779392188153:task-definition/example-ecs-task-definition:1",


### PR DESCRIPTION
A recent Rego SDK updation https://github.com/flatt-security/shisho-cloud-rego-libraries/pull/5 introduced validation for payloads. This PR bumps up Rego SDK referenced from this repository, and also fixes a typo/formatting issue found by the validation logic. 

Disclaimer: As same as #5 the typo will NOT prevent policies from making proper decisions (i.e. the security check resulsts are legitimate even with the typo), but it is just confusing!