### PR TITLE
feat: add the triager to the notification

### DIFF
--- a/workflows/notification/slack/security-ja/triage/notify.graphql
+++ b/workflows/notification/slack/security-ja/triage/notify.graphql
@@ -28,6 +28,13 @@ query {
             name
             viewer
           }
+
+          triageComment
+          triageInitiator {
+            id
+            type
+            displayName
+          }
         }
       }
     }


### PR DESCRIPTION
This PR adds the triager name to the notification. It should be like:

<img width="542" alt="image" src="https://github.com/flatt-security/shisho-cloud-managed-workflows/assets/1256823/66c4de8a-ee84-4c23-8ac8-82b802313c89">
