### PR TITLE
feat: exclude with service account email for service-account-project-admin-role

### DIFF
--- a/workflows/cis-benchmark/googlecloud-v1.3.0/iam/manifest.yaml
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/iam/manifest.yaml
@@ -42,6 +42,11 @@ jobs:
           multiple: true
           description: A special list of resource exceptions
           values: []
+        allowed_service_account_email_regexes:
+          type: string
+          multiple: true
+          description: A list of service account email regexes (e.g. .*@example\.iam\.gserviceaccount\.com) that are allowed to be attached with project admin role
+          values: []
       input:
         schema: !include service-account-project-admin-role/decide.graphql
   - id: principal-source

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/iam/service-account-project-admin-role/decide.rego
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/iam/service-account-project-admin-role/decide.rego
@@ -2,6 +2,12 @@ package policy.googlecloud.iam.service_account_project_admin_role
 
 import data.shisho
 
+# the list of allowed service account emails using regex
+allowed_service_account_email_regexes := data.params.allowed_service_account_email_regexes {
+	data.params != null
+	data.params.allowed_service_account_email_regexes != null
+} else := []
+
 decisions[d] {
 	project := input.googleCloud.projects[_]
 
@@ -24,6 +30,7 @@ permissive_project_bindings(bindings) := x {
 		member := binding.members[_]
 		member.__typename == "GoogleCloudIAMPrincipalServiceAccount"
 		member.email != null
+		is_allowed_service_account(member.email) == false
 	]
 } else := []
 
@@ -36,3 +43,7 @@ is_suspicious_role(role) {
 } else {
 	role == "roles/owner"
 } else = false
+
+is_allowed_service_account(d) {
+	regex.match(allowed_service_account_email_regexes[_], d)
+} else := false

--- a/workflows/cis-benchmark/googlecloud-v1.3.0/iam/service-account-project-admin-role/decide_test.rego
+++ b/workflows/cis-benchmark/googlecloud-v1.3.0/iam/service-account-project-admin-role/decide_test.rego
@@ -85,3 +85,49 @@ test_permissive_project_iam_policy_failss if {
 		},
 	]}}
 }
+
+test_service_account_project_admin_role_with_allowed_service_account if {
+	test_input := {"googleCloud": {"projects": [
+		{
+			"id": "test-project-1",
+			"metadata": {"id": "googlecloud-project|5148937777"},
+			"iamPolicy": {"bindings": [{
+				"members": [{"__typename": "GoogleCloudIAMPrincipalServiceAccount", "email": "app@test-project-1.iam.gserviceaccount.com"}],
+				"role": "roles/owner",
+			}]},
+		},
+		{
+			"id": "test-project-2",
+			"metadata": {"id": "googlecloud-project|5148938888"},
+			"iamPolicy": {"bindings": [{
+				"members": [{"__typename": "GoogleCloudIAMPrincipalServiceAccount", "email": "admin@example-organization.iam.gserviceaccount.com"}],
+				"role": "roles/owner",
+			}]},
+		},
+		{
+			"id": "test-project-3",
+			"metadata": {"id": "googlecloud-project|5148939999"},
+			"iamPolicy": {"bindings": [{
+				"members": [{"__typename": "GoogleCloudIAMPrincipalServiceAccount", "email": "owner@example-organization.iam.gserviceaccount.com"}],
+				"role": "roles/owner",
+			}]},
+		},
+	]}}
+
+	count([d |
+		decisions[d]
+		not shisho.decision.is_allowed(d)
+	]) == 3 with input as test_input
+
+	count([d |
+		decisions[d]
+		not shisho.decision.is_allowed(d)
+	]) == 1 with input as test_input
+		with data.params.allowed_service_account_email_regexes as {"admin@example-organization\\.iam\\.gserviceaccount\\.com", ".*@example-organization\\.iam\\.gserviceaccount\\.com"}
+
+	count([d |
+		decisions[d]
+		shisho.decision.is_allowed(d)
+	]) == 0 with input as test_input
+		with data.params.allowed_service_account_email_regexes as {"*"}
+}


### PR DESCRIPTION
# Overview

add `allowed_service_account_email_regexes` for `service-account-project-admin-role`

## Concern

This feature is applied to all projects. I thought it might be better if it could be set for each project, or if specific projects could be excluded. However, doing so would make things more complicated.