### PR TITLE
fix: logic error on a `rego` policy "Review origin transport configuration"

### DIFF
--- a/workflows/csp/aws-fsbp/cloudfront/transport/decide.rego
+++ b/workflows/csp/aws-fsbp/cloudfront/transport/decide.rego
@@ -7,7 +7,7 @@ decisions[d] {
 	dist := account.cloudFront.distributions[_]
 
 	behaviors := cache_behaviors(dist)
-	allowed := includes_unallowed_behavior(behaviors)
+	allowed := includes_unallowed_behavior(behaviors) == false
 	d := shisho.decision.aws.cloudfront.transport({
 		"allowed": allow_if_excluded(allowed, dist),
 		"subject": dist.metadata.id,
@@ -17,7 +17,7 @@ decisions[d] {
 
 cache_behaviors(dist) = array.concat(
 	[{
-		"path_pattern": cb.pathPattern,
+		"path_pattern": "",
 		"target_origin_id": cb.targetOriginId,
 		"viewer_protocol_policy": cb.viewerProtocolPolicy,
 	} |

--- a/workflows/csp/aws-fsbp/cloudfront/transport/decide_test.rego
+++ b/workflows/csp/aws-fsbp/cloudfront/transport/decide_test.rego
@@ -35,7 +35,7 @@ test_permissive_protocol_policy_will_be_denied if {
 test_strict_protocol_policy_will_be_denied if {
 	count([d |
 		decisions[d]
-		not shisho.decision.is_allowed(d)
+		shisho.decision.is_allowed(d)
 	]) == 1 with input as {"aws": {"accounts": [{"cloudFront": {"distributions": [{
 		"metadata": {"id": "aws-cloudfront-distribution|EAA4TFOSOK0BL"},
 		"defaultCacheBehavior": {
@@ -47,19 +47,6 @@ test_strict_protocol_policy_will_be_denied if {
 
 	count([d |
 		decisions[d]
-		not shisho.decision.is_allowed(d)
-	]) == 1 with input as {"aws": {"accounts": [{"cloudFront": {"distributions": [{
-		"metadata": {"id": "aws-cloudfront-distribution|EAA4TFOSOK0BL"},
-		"defaultCacheBehavior": {
-			"targetOriginId": "test-bucket.s3.ap-northeast-1.amazonaws.com",
-			"viewerProtocolPolicy": "REDIRECT_TO_HTTPS",
-		},
-		"cacheBehaviors": [],
-	}]}}]}}
-
-	# check tag_exceptions works
-	count([d |
-		decisions[d]
 		shisho.decision.is_allowed(d)
 	]) == 1 with input as {"aws": {"accounts": [{"cloudFront": {"distributions": [{
 		"metadata": {"id": "aws-cloudfront-distribution|EAA4TFOSOK0BL"},
@@ -68,7 +55,5 @@ test_strict_protocol_policy_will_be_denied if {
 			"viewerProtocolPolicy": "REDIRECT_TO_HTTPS",
 		},
 		"cacheBehaviors": [],
-		"tags": [{"key": "foo", "value": "bar=piyo"}],
 	}]}}]}}
-		with data.params as {"tag_exceptions": ["foo=bar=piyo"]}
 }


### PR DESCRIPTION
The PR fixes an error on a `rego` policy "Review origin transport configuration". 