### PR TITLE
fix: remove a criteria on `keyEnabled` on S3 bucket encryption checks

### DIFF
--- a/workflows/cis-benchmark/aws-v1.5.0/s3/bucket-encryption/decide.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/s3/bucket-encryption/decide.rego
@@ -18,7 +18,7 @@ decisions[d] {
 
 includes_accepted_encryption_rule(rules) {
 	rule := rules[_]
-	rule.keyEnabled == true
+
 	any([
 		rule.encryptionByDefault.sseAlgorithm == "AES256",
 		rule.encryptionByDefault.sseAlgorithm == "AWS_KMS",

--- a/workflows/cis-benchmark/aws-v1.5.0/s3/bucket-encryption/decide_test.rego
+++ b/workflows/cis-benchmark/aws-v1.5.0/s3/bucket-encryption/decide_test.rego
@@ -11,38 +11,11 @@ test_whether_the_bucket_encryption_is_enabled_for_aws_s3_buckets if {
 	]) == 2 with input as {"aws": {"accounts": [{"s3": {"buckets": [
 		{
 			"metadata": {"id": "aws-s3-bucket|ap-northeast-1|test-bucket-1"},
-			"encryptionConfiguration": {"rules": [{
-				"encryptionByDefault": {"sseAlgorithm": "AES256"},
-				"keyEnabled": true,
-			}]},
+			"encryptionConfiguration": {"rules": [{"encryptionByDefault": {"sseAlgorithm": "AES256"}}]},
 		},
 		{
 			"metadata": {"id": "aws-s3-bucket|ap-northeast-1|test-bucket-2"},
-			"encryptionConfiguration": {"rules": [{
-				"encryptionByDefault": {"sseAlgorithm": "AWS_KMS"},
-				"keyEnabled": true,
-			}]},
-		},
-	]}}]}}
-
-	# check if the bucket encryption is disabled for AWS S3 buckets
-	count([d |
-		decisions[d]
-		not shisho.decision.is_allowed(d)
-	]) == 2 with input as {"aws": {"accounts": [{"s3": {"buckets": [
-		{
-			"metadata": {"id": "aws-s3-bucket|ap-northeast-1|test-bucket-1"},
-			"encryptionConfiguration": {"rules": [{
-				"encryptionByDefault": {"sseAlgorithm": "AES256"},
-				"keyEnabled": false,
-			}]},
-		},
-		{
-			"metadata": {"id": "aws-s3-bucket|ap-northeast-1|test-bucket-2"},
-			"encryptionConfiguration": {"rules": [{
-				"encryptionByDefault": {"sseAlgorithm": "INSECURE_ALGORITHM"},
-				"keyEnabled": true,
-			}]},
+			"encryptionConfiguration": {"rules": [{"encryptionByDefault": {"sseAlgorithm": "AWS_KMS"}}]},
 		},
 	]}}]}}
 
@@ -53,18 +26,12 @@ test_whether_the_bucket_encryption_is_enabled_for_aws_s3_buckets if {
 	]) == 1 with input as {"aws": {"accounts": [{"s3": {"buckets": [
 		{
 			"metadata": {"id": "aws-s3-bucket|ap-northeast-1|test-bucket-1"},
-			"encryptionConfiguration": {"rules": [{
-				"encryptionByDefault": {"sseAlgorithm": "AES256"},
-				"keyEnabled": false,
-			}]},
+			"encryptionConfiguration": {"rules": [{"encryptionByDefault": {"sseAlgorithm": "AES256"}}]},
 			"tags": [{"key": "foo", "value": "bar=piyo"}],
 		},
 		{
 			"metadata": {"id": "aws-s3-bucket|ap-northeast-1|test-bucket-2"},
-			"encryptionConfiguration": {"rules": [{
-				"encryptionByDefault": {"sseAlgorithm": "INSECURE_ALGORITHM"},
-				"keyEnabled": true,
-			}]},
+			"encryptionConfiguration": {"rules": [{"encryptionByDefault": {"sseAlgorithm": "INSECURE_ALGORITHM"}}]},
 			"tags": [{"key": "foo", "value": "diff"}],
 		},
 	]}}]}}


### PR DESCRIPTION
This PR removes a criteria on `keyEnabled` on S3 bucket encryption checks, because it causes false positive for S3 buckets with default encryption settings WITHOUT S3 bucket keys.